### PR TITLE
Use OS config dir for default config location

### DIFF
--- a/cloudomate/util/config.py
+++ b/cloudomate/util/config.py
@@ -1,16 +1,31 @@
 import ConfigParser
+from ConfigParser import NoSectionError
+
+from appdirs import *
 
 
 class UserOptions(object):
     def __init__(self):
         self.config = {}
 
-    def read_settings(self, filename="./cloudomate.cfg"):
+    def read_settings(self, filename=None):
         cp = ConfigParser.ConfigParser()
+        if not filename:
+            config_dir = user_config_dir()
+            filename = os.path.join(config_dir, 'cloudomate.cfg')
+
+        if not os.path.exists(filename):
+            print("cloudomate.cfg not found at %s" % filename)
+            return False
         cp.read(filename)
-        self._merge(cp.items("User"))
-        self._merge(cp.items("Address"))
-        self._merge(cp.items("Server"))
+        try:
+            self._merge(cp.items("User"))
+            self._merge(cp.items("Address"))
+            self._merge(cp.items("Server"))
+        except NoSectionError, e:
+            print(e.message)
+            return False
+        return True
 
     def _merge(self, items):
         for key, value in items:


### PR DESCRIPTION
For Linux this is $HOME/.config/cloudomate.cfg, appdirs finds the appropriate directory. It's not desirable to have the default config in the current working directory or in the root of the project, instead OS conventions are followed now for choosing an appropriate location.