### PR TITLE
Manage

### DIFF
--- a/cloudomate/cmdline.py
+++ b/cloudomate/cmdline.py
@@ -194,7 +194,7 @@ def _purchase(provider, vps_option, user_settings):
     if user_settings.get("noconfirm") is not None and user_settings.get("noconfirm") is True:
         choice = True
     else:
-        choice = _confirmation("Puchase this option?", default="no")
+        choice = _confirmation("Purchase this option?", default="no")
     if choice:
         _register(provider, vps_option, user_settings)
     else:

--- a/cloudomate/test/test_cmdline.py
+++ b/cloudomate/test/test_cmdline.py
@@ -34,7 +34,7 @@ class TestCmdLine(unittest.TestCase):
     def test_execute_purchase(self):
         self._mock_options([self._create_option()])
         RockHoster.purchase = MagicMock()
-        command = ["purchase", "rockhoster", "-c", "config_test.cfg", "-rp", "asdf", "0"]
+        command = ["purchase", "rockhoster", "-f", "-c", "config_test.cfg", "-rp", "asdf", "0"]
         cmdline.execute(command)
         RockHoster.purchase.assert_called_once()
 
@@ -50,11 +50,11 @@ class TestCmdLine(unittest.TestCase):
         return option
 
     def test_execute_purchase_verify_options_failure(self):
-        command = ["purchase", "rockhoster", "-c", "config_test.cfg", "1"]
+        command = ["purchase", "rockhoster", "-f", "-c", "config_test.cfg", "1"]
         self._check_exit_code(2, cmdline.execute, command)
 
     def test_execute_purchase_unknown_provider(self):
-        command = ["purchase", "nonode", "-rp", "asdf", "1"]
+        command = ["purchase", "nonode", "-f", "-rp", "asdf", "1"]
         self._check_exit_code(2, cmdline.execute, command)
 
     def test_execute_options_unknown_provider(self):

--- a/cloudomate/vps/blueangelhost.py
+++ b/cloudomate/vps/blueangelhost.py
@@ -1,6 +1,7 @@
 import mechanize
 from bs4 import BeautifulSoup
 
+from cloudomate.vps.clientarea import ClientArea
 from cloudomate.vps.hoster import Hoster
 from cloudomate.vps.vpsoption import VpsOption
 from cloudomate.gateway.bitpay import extract_info
@@ -11,7 +12,7 @@ class BlueAngelHost(Hoster):
     name = "blueangelhost"
     website = "https://www.blueangelhost.com/"
     required_settings = ["rootpw"]
-    browser = None
+    clientarea_url = 'https://www.billing.blueangelhost.com/clientarea.php'
 
     def purchase(self, user_settings, vps_option):
         """
@@ -129,6 +130,28 @@ class BlueAngelHost(Hoster):
         option.purchase_url = column.find('a')['href']
         return option
 
+    def get_status(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
+        clientarea.print_services()
 
-if __name__ == "__main__":
-    BlueAngelHost.start()
+    def set_rootpw(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
+        rootpw = user_settings.get('rootpw')
+        if 'number' in user_settings.config:
+            clientarea.set_rootpw(rootpw, int(user_settings.get('number')))
+        else:
+            clientarea.set_rootpw(rootpw)
+
+    def get_ip(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
+        client_data_url = 'https://www.billing.blueangelhost.com/modules/servers/solusvmpro/get_client_data.php'
+        if 'number' in user_settings.config:
+            clientarea.get_ip(client_data_url, int(user_settings.get('number')))
+        else:
+            clientarea.get_ip(client_data_url)

--- a/cloudomate/vps/blueangelhost.py
+++ b/cloudomate/vps/blueangelhost.py
@@ -1,7 +1,6 @@
 import mechanize
 from bs4 import BeautifulSoup
 
-from cloudomate.vps.clientarea import ClientArea
 from cloudomate.vps.hoster import Hoster
 from cloudomate.vps.vpsoption import VpsOption
 from cloudomate.gateway.bitpay import extract_info
@@ -13,6 +12,7 @@ class BlueAngelHost(Hoster):
     website = "https://www.blueangelhost.com/"
     required_settings = ["rootpw"]
     clientarea_url = 'https://www.billing.blueangelhost.com/clientarea.php'
+    client_data_url = 'https://www.billing.blueangelhost.com/modules/servers/solusvmpro/get_client_data.php'
 
     def purchase(self, user_settings, vps_option):
         """
@@ -131,27 +131,10 @@ class BlueAngelHost(Hoster):
         return option
 
     def get_status(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
-        clientarea.print_services()
+        self._clientarea_get_status(user_settings, self.clientarea_url)
 
     def set_rootpw(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
-        rootpw = user_settings.get('rootpw')
-        if 'number' in user_settings.config:
-            clientarea.set_rootpw(rootpw, int(user_settings.get('number')))
-        else:
-            clientarea.set_rootpw(rootpw)
+        self._clientarea_set_rootpw(user_settings, self.clientarea_url)
 
     def get_ip(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.browser, self.clientarea_url, email, password)
-        client_data_url = 'https://www.billing.blueangelhost.com/modules/servers/solusvmpro/get_client_data.php'
-        if 'number' in user_settings.config:
-            clientarea.get_ip(client_data_url, int(user_settings.get('number')))
-        else:
-            clientarea.get_ip(client_data_url)
+        self._clientarea_get_ip(user_settings, self.clientarea_url, self.client_data_url)

--- a/cloudomate/vps/ccihosting.py
+++ b/cloudomate/vps/ccihosting.py
@@ -1,5 +1,5 @@
-import mechanize
 import sys
+
 from bs4 import BeautifulSoup
 
 from cloudomate.vps.hoster import Hoster
@@ -9,6 +9,7 @@ from cloudomate.vps.vpsoption import VpsOption
 class CCIHosting(Hoster):
     name = "ccihosting"
     website = "http://www.ccihosting.com/"
+    clientarea_url = "https://www.ccihosting.com/accounts/clientarea.php"
     required_settings = [
         'firstname',
         'lastname',
@@ -135,6 +136,11 @@ class CCIHosting(Hoster):
         option.purchase_url = column.find('a')['href']
         return option
 
+    def get_status(self, user_settings):
+        self._clientarea_get_status(user_settings, self.clientarea_url)
 
-if __name__ == "__main__":
-    CCIHosting.start()
+    def set_rootpw(self, user_settings):
+        self._clientarea_set_rootpw(user_settings, self.clientarea_url)
+
+    def get_ip(self, user_settings):
+        self._clientarea_get_ip(user_settings, self.clientarea_url, self.client_data_url)

--- a/cloudomate/vps/clientarea.py
+++ b/cloudomate/vps/clientarea.py
@@ -57,15 +57,14 @@ class ClientArea(object):
         Print parsed VPS configurations.
         """
         self._services()
-        row_format = "{:5}" + "{:15}" * 6
-        print(row_format.format('#', 'Product', 'Host', 'Price', 'Term', 'Next due date', 'Status', 'Id'))
+        row_format = "{:5}" + "{:15}" * 5
+        print(row_format.format('#', 'Product', 'Price', 'Term', 'Next due date', 'Status', 'Id'))
 
         i = 0
         for service in self.services:
             print(row_format.format(
                 str(i),
                 service['product'],
-                service['host'],
                 service['price'],
                 service['term'],
                 service['next_due_date'],
@@ -86,7 +85,6 @@ class ClientArea(object):
             self.services.append({
                 'id': tds[4].a['href'].split('id=')[1],
                 'product': tds[0].strong.text,
-                'host': tds[0].a.text,
                 'price': tds[1].text.split('USD')[0],
                 'term': tds[1].text.split('USD')[1],
                 'next_due_date': tds[2].text[0:10],
@@ -105,6 +103,9 @@ class ClientArea(object):
             print("Wrong index: %s not between 0 and %s" % (number, len(self.services) - 1))
             sys.exit(2)
         service = self.services[number]
+        if service['status'] != 'Active':
+            print("Unable to obtain ip: service is %s" % (service['status']))
+            sys.exit(2)
         vserverid = self._get_vserverid(service['url'])
         millis = int(round(time.time() * 1000))
         page = self.browser.open(client_data_url + '?vserverid=%s&_=%s' % (vserverid, millis))

--- a/cloudomate/vps/clientarea.py
+++ b/cloudomate/vps/clientarea.py
@@ -25,7 +25,10 @@ class ClientArea(object):
         :return: The clientarea homepage on succesful login.
         """
         self.browser.open(self.clientarea_url)
-        self.browser.select_form(nr=0)
+        if len(list(self.browser.forms())) > 1:
+            self.browser.select_form(nr=1)
+        else:
+            self.browser.select_form(nr=0)
         self.browser.form['username'] = email
         self.browser.form['password'] = password
         page = self.browser.submit()

--- a/cloudomate/vps/clientarea.py
+++ b/cloudomate/vps/clientarea.py
@@ -1,0 +1,133 @@
+import re
+import sys
+import time
+
+from bs4 import BeautifulSoup
+from flask import json
+
+
+class ClientArea(object):
+    """
+    Clientarea is the name of the control panel used in many VPS providers. The purpose of this class is to use
+    this control panel in an automated manner.
+    """
+
+    def __init__(self, browser, clientarea_url, email, password):
+        self.browser = browser
+        self.clientarea_url = clientarea_url
+        self.home_page = None
+        self.services = None
+        self._login(email, password)
+
+    def _login(self, email, password):
+        """
+        Login into the clientarea. Exits program if unsuccesful.
+        :return: The clientarea homepage on succesful login.
+        """
+        self.browser.open(self.clientarea_url)
+        self.browser.select_form(nr=0)
+        self.browser.form['username'] = email
+        self.browser.form['password'] = password
+        page = self.browser.submit()
+        if "incorrect=true" in page.geturl():
+            print("Login failure")
+            sys.exit(2)
+        self.home_page = page
+
+    def number_of_services(self):
+        """
+        Return the number of services.
+        :return: 
+        """
+        soup = BeautifulSoup(self.home_page.get_data(), 'lxml')
+        stat = soup.find('div', {'class': 'col-sm-3 col-xs-6 tile'}).a.find('div', {'class': 'stat'})
+        return stat.text
+
+    def get_services(self):
+        """
+        Parse and list purchased services from clientarea_url?a=action.
+        :return: the list of services in dict format.
+        """
+        if self.services is None:
+            self._services()
+        return self.services
+
+    def print_services(self):
+        """
+        Print parsed VPS configurations.
+        """
+        self._services()
+        row_format = "{:5}" + "{:15}" * 6
+        print(row_format.format('#', 'Product', 'Host', 'Price', 'Term', 'Next due date', 'Status', 'Id'))
+
+        i = 0
+        for service in self.services:
+            print(row_format.format(
+                str(i),
+                service['product'],
+                service['host'],
+                service['price'],
+                service['term'],
+                service['next_due_date'],
+                service['status'],
+                service['id'],
+            ))
+            i = i + 1
+
+    def _services(self):
+        if self.services is not None:
+            return
+        services_page = self.browser.open(self.clientarea_url + "?action=services")
+        soup = BeautifulSoup(services_page.get_data(), 'lxml')
+        rows = soup.find('table', {'id': 'tableServicesList'}).tbody.findAll('tr')
+        self.services = []
+        for row in rows:
+            tds = row.findAll('td', recursive=False)
+            self.services.append({
+                'id': tds[4].a['href'].split('id=')[1],
+                'product': tds[0].strong.text,
+                'host': tds[0].a.text,
+                'price': tds[1].text.split('USD')[0],
+                'term': tds[1].text.split('USD')[1],
+                'next_due_date': tds[2].text[0:10],
+                'status': tds[3].text,
+                'url': self.clientarea_url + tds[4].a['href'].split('.php')[1],
+            })
+
+    def _get_vserverid(self, url):
+        page = self.browser.open(url)
+        match = re.search(r'vserverid = (\d+)', page.get_data())
+        return match.group(1)
+
+    def get_ip(self, client_data_url, number=0):
+        self._services()
+        if not 0 <= number < len(self.services):
+            print("Wrong index: %s not between 0 and %s" % (number, len(self.services) - 1))
+            sys.exit(2)
+        service = self.services[number]
+        vserverid = self._get_vserverid(service['url'])
+        millis = int(round(time.time() * 1000))
+        page = self.browser.open(client_data_url + '?vserverid=%s&_=%s' % (vserverid, millis))
+        data = json.loads(page.get_data())
+        print(data['mainip'])
+
+    def set_rootpw(self, password, number=0):
+        self._services()
+        if not 0 <= number < len(self.services):
+            print("Wrong index: %s not between 0 and %s" % (number, len(self.services) - 1))
+            sys.exit(2)
+        service = self.services[number]
+        millis = int(round(time.time() * 1000))
+
+        print("Changing password for %s" % service['id'])
+        vserverid = self._get_vserverid(service['url'])
+        url = self.clientarea_url + '?action=productdetails&id=%s&vserverid=%s&modop=custom&a=ChangeRootPassword' \
+                                    '&newrootpassword=%s&ajax=1&ac=Custom_ChangeRootPassword&_=%s' \
+                                    % (service['id'], vserverid, password, millis)
+        print(url)
+        response = self.browser.open(url)
+        response_json = json.loads(response.get_data())
+        if response_json['success'] is True:
+            print("Password changed successfully")
+        else:
+            print(response_json['msg'])

--- a/cloudomate/vps/clientarea.py
+++ b/cloudomate/vps/clientarea.py
@@ -1,9 +1,9 @@
+import json
 import re
 import sys
 import time
 
 from bs4 import BeautifulSoup
-from flask import json
 
 
 class ClientArea(object):

--- a/cloudomate/vps/crowncloud.py
+++ b/cloudomate/vps/crowncloud.py
@@ -12,13 +12,11 @@ class CrownCloud(Hoster):
     name = "crowncloud"
     website = "http://crowncloud.net/"
     required_settings = ["rootpw"]
-    br = None
+    clientarea_url = 'https://crowncloud.net/clients/clientarea.php'
+    client_data_url = 'https://crowncloud.net/clients/modules/servers/solusvmpro/get_client_data.php'
 
     def __init__(self):
         self.br = self._create_browser()
-        # self.br.set_debug_redirects(True)
-        # self.br.set_debug_http(True)
-        # self.br.set_debug_responses(True)
         pass
 
     def purchase(self, user_settings, vps_option):
@@ -138,6 +136,12 @@ class CrownCloud(Hoster):
         option.purchase_url = elements[9].find('a')['href']
         return option
 
+    def get_status(self, user_settings):
+        self._clientarea_get_status(user_settings, self.clientarea_url)
 
-if __name__ == "__main__":
-    CrownCloud.start()
+    def set_rootpw(self, user_settings):
+        self._clientarea_set_rootpw(user_settings, self.clientarea_url)
+
+    def get_ip(self, user_settings):
+        self._clientarea_get_ip(user_settings, self.clientarea_url, self.client_data_url)
+

--- a/cloudomate/vps/hoster.py
+++ b/cloudomate/vps/hoster.py
@@ -4,7 +4,6 @@ At this time there is no abstract implementation for any functionality.
 """
 import os
 import random
-import re
 import webbrowser
 from tempfile import mkstemp
 from urlparse import urlparse
@@ -46,9 +45,43 @@ class Hoster(object):
     configurations = None
 
     def options(self):
+        """
+        List the available VPS options for specified provider.
+        :return: 
+        """
         raise NotImplementedError('Abstract method implementation')
 
     def purchase(self, user_settings, vps_option):
+        """
+        Purchase an instance of specified provider.
+        :param user_settings: the user settings used for registration.
+        :param vps_option: the vps option to purchase.
+        :return: 
+        """
+        raise NotImplementedError('Abstract method implementation')
+
+    def get_status(self, user_settings):
+        """
+        Get the status of purchased services for specified provider.
+        :param user_settings: the user settings used to login.
+        :return: 
+        """
+        raise NotImplementedError('Abstract method implementation')
+
+    def set_rootpw(self, user_settings):
+        """
+        Set the root password for the last purchased service of specified provider.
+        :param user_settings: the user settings including root password and login data.
+        :return: 
+        """
+        raise NotImplementedError('Abstract method implementation')
+
+    def get_ip(self, user_settings):
+        """
+        Get the ip for the last purchased service of specified provider.
+        :param user_settings: the user settings including root password and login data.
+        :return: 
+        """
         raise NotImplementedError('Abstract method implementation')
 
     def print_configurations(self):

--- a/cloudomate/vps/hoster.py
+++ b/cloudomate/vps/hoster.py
@@ -12,6 +12,8 @@ from mechanize import Browser
 from forex_python.bitcoin import BtcConverter
 from cloudomate import wallet
 
+from cloudomate.vps.clientarea import ClientArea
+
 user_agents = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36",
@@ -43,6 +45,7 @@ class Hoster(object):
     website = None
     required_settings = None
     configurations = None
+    client_area = None
 
     def options(self):
         """
@@ -132,3 +135,28 @@ class Hoster(object):
         os.close(fd)
 
         webbrowser.open(path)
+
+    def _clientarea_set_rootpw(self, user_settings, clientarea_url):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self._create_browser(), clientarea_url, email, password)
+        rootpw = user_settings.get('rootpw')
+        if 'number' in user_settings.config:
+            clientarea.set_rootpw(rootpw, int(user_settings.get('number')))
+        else:
+            clientarea.set_rootpw(rootpw)
+
+    def _clientarea_get_status(self, user_settings, clientarea_url):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self._create_browser(), clientarea_url, email, password)
+        clientarea.print_services()
+
+    def _clientarea_get_ip(self, user_settings, clientarea_url, client_data_url):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self._create_browser(), clientarea_url, email, password)
+        if 'number' in user_settings.config:
+            clientarea.get_ip(client_data_url, int(user_settings.get('number')))
+        else:
+            clientarea.get_ip(client_data_url)

--- a/cloudomate/vps/pulseservers.py
+++ b/cloudomate/vps/pulseservers.py
@@ -1,11 +1,10 @@
+import sys
+
 from bs4 import BeautifulSoup as soup
 
+from cloudomate.gateway.coinbase import extract_info
 from cloudomate.vps.hoster import Hoster
 from cloudomate.vps.vpsoption import VpsOption
-
-from cloudomate.gateway.coinbase import extract_info
-
-import sys
 
 
 class Pulseservers(Hoster):
@@ -29,6 +28,7 @@ class Pulseservers(Hoster):
         'hostname',
         'rootpw'
     ]
+    clientarea_url = 'https://www.pulseservers.com/billing/clientarea.php'
 
     def options(self):
         """
@@ -176,6 +176,11 @@ class Pulseservers(Hoster):
         self.browser.form['paymentmethod'] = ['coinbase']
         self.browser.find_control('accepttos').items[0].selected = True
 
+    def get_status(self, user_settings):
+        self._clientarea_get_status(user_settings, self.clientarea_url)
 
-if __name__ == '__main__':
-    Pulseservers.purchase({}, Pulseservers().options()[1])
+    def set_rootpw(self, user_settings):
+        self._clientarea_set_rootpw(user_settings, self.clientarea_url)
+
+    def get_ip(self, user_settings):
+        self._clientarea_get_ip(user_settings, self.clientarea_url, self.client_data_url)

--- a/cloudomate/vps/rockhoster.py
+++ b/cloudomate/vps/rockhoster.py
@@ -2,6 +2,7 @@ import itertools
 
 from bs4 import BeautifulSoup
 
+from cloudomate.vps.clientarea import ClientArea
 from cloudomate.vps.hoster import Hoster
 from cloudomate.vps.vpsoption import VpsOption
 
@@ -22,7 +23,7 @@ class RockHoster(Hoster):
         'password',
         'hostname',
         'rootpw']
-    br = None
+    clientarea_url = 'https://rockhoster.com/cloud/clientarea.php'
 
     def __init__(self):
         self.br = self._create_browser()
@@ -56,17 +57,6 @@ class RockHoster(Hoster):
         self.fill_in_user_form(user_settings)
         self.br.submit()
         self.br.follow_link(url_regex="coinbase")
-
-    def login(self, user_settings):
-        """
-        Login into the RockHoster clientarea.
-        :return: 
-        """
-        self.br.open("https://rockhoster.com/cloud/clientarea.php")
-        self.br.select_form(nr=0)
-        self.br.form['username'] = user_settings.get('email')
-        self.br.form['password'] = user_settings.get('password')
-        page = self.br.submit()
 
     def number_of_services(self):
         page = self.br.open("https://rockhoster.com/cloud/clientarea.php")
@@ -176,3 +166,30 @@ class RockHoster(Hoster):
         option.price = option.price.split('/')[0]
         option.purchase_url = column.find('div', {'class': 'bottom'}).a['href']
         return option
+
+    def get_status(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
+        clientarea.get_services()
+        clientarea.print_services()
+
+    def set_rootpw(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
+        rootpw = user_settings.get('rootpw')
+        if 'number' in user_settings.config:
+            clientarea.set_rootpw(rootpw, int(user_settings.get('number')))
+        else:
+            clientarea.set_rootpw(rootpw)
+
+    def get_ip(self, user_settings):
+        email = user_settings.get('email')
+        password = user_settings.get('password')
+        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
+        client_data_url = 'https://rockhoster.com/cloud/modules/servers/solusvmpro/get_client_data.php'
+        if 'number' in user_settings.config:
+            clientarea.get_ip(client_data_url, int(user_settings.get('number')))
+        else:
+            clientarea.get_ip(client_data_url)

--- a/cloudomate/vps/rockhoster.py
+++ b/cloudomate/vps/rockhoster.py
@@ -2,7 +2,6 @@ import itertools
 
 from bs4 import BeautifulSoup
 
-from cloudomate.vps.clientarea import ClientArea
 from cloudomate.vps.hoster import Hoster
 from cloudomate.vps.vpsoption import VpsOption
 
@@ -24,6 +23,7 @@ class RockHoster(Hoster):
         'hostname',
         'rootpw']
     clientarea_url = 'https://rockhoster.com/cloud/clientarea.php'
+    client_data_url = 'https://rockhoster.com/cloud/modules/servers/solusvmpro/get_client_data.php'
 
     def __init__(self):
         self.br = self._create_browser()
@@ -57,12 +57,6 @@ class RockHoster(Hoster):
         self.fill_in_user_form(user_settings)
         self.br.submit()
         self.br.follow_link(url_regex="coinbase")
-
-    def number_of_services(self):
-        page = self.br.open("https://rockhoster.com/cloud/clientarea.php")
-        soup = BeautifulSoup(page.get_data(), 'lxml')
-        stat = soup.find('div', {'class': 'col-sm-3 col-xs-6 tile'}).a.find('div', {'class': 'stat'})
-        return stat.text
 
     def fill_in_server_form(self, user_settings):
         """
@@ -168,28 +162,10 @@ class RockHoster(Hoster):
         return option
 
     def get_status(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
-        clientarea.get_services()
-        clientarea.print_services()
+        self._clientarea_get_status(user_settings, self.clientarea_url)
 
     def set_rootpw(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
-        rootpw = user_settings.get('rootpw')
-        if 'number' in user_settings.config:
-            clientarea.set_rootpw(rootpw, int(user_settings.get('number')))
-        else:
-            clientarea.set_rootpw(rootpw)
+        self._clientarea_set_rootpw(user_settings, self.clientarea_url)
 
     def get_ip(self, user_settings):
-        email = user_settings.get('email')
-        password = user_settings.get('password')
-        clientarea = ClientArea(self.br, self.clientarea_url, email, password)
-        client_data_url = 'https://rockhoster.com/cloud/modules/servers/solusvmpro/get_client_data.php'
-        if 'number' in user_settings.config:
-            clientarea.get_ip(client_data_url, int(user_settings.get('number')))
-        else:
-            clientarea.get_ip(client_data_url)
+        self._clientarea_get_ip(user_settings, self.clientarea_url, self.client_data_url)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'cloudomate=cloudomate:cmdline',
+            'cloudomate=cloudomate.cmdline:execute',
         ],
     },
 )


### PR DESCRIPTION
Add the following functions for all current providers:
`cloudomate getip <provider>`: Get the IP address of the first or specified VPS instance.
`cloudomate status <provider>`: Get the status of purchased and activated VPS instances.
`cloudomate setrootpw -p ROOTPW <provider>`: Set the rootpassword for the first or specified VPS instance.

All current providers use clientarea.php, clientarea.py contains common functions for operating the client area.