### PR TITLE
Add support for provider specific sections.

### DIFF
--- a/cloudomate/cmdline.py
+++ b/cloudomate/cmdline.py
@@ -103,7 +103,7 @@ def set_rootpw(args):
         _print_unknown_provider(provider)
         _list_providers()
         sys.exit(2)
-    user_settings = _get_user_settings(args)
+    user_settings = _get_user_settings(args, provider)
     p = providers[provider]
     p.set_rootpw(user_settings)
 
@@ -114,7 +114,7 @@ def get_ip(args):
         _print_unknown_provider(provider)
         _list_providers()
         sys.exit(2)
-    user_settings = _get_user_settings(args)
+    user_settings = _get_user_settings(args, provider)
     p = providers[provider]
     p.get_ip(user_settings)
 
@@ -126,7 +126,7 @@ def status(args):
         _list_providers()
         sys.exit(2)
     print("Getting status for %s." % provider)
-    user_settings = _get_user_settings(args)
+    user_settings = _get_user_settings(args, provider)
     p = providers[provider]
     p.get_status(user_settings)
 
@@ -148,7 +148,7 @@ def purchase(args):
         _print_unknown_provider(provider)
         _list_providers()
         sys.exit(2)
-    user_settings = _get_user_settings(args)
+    user_settings = _get_user_settings(args, provider)
     if not _check_provider(provider, user_settings):
         print("Missing option")
         sys.exit(2)
@@ -160,12 +160,12 @@ def _check_provider(provider, config):
     return config.verify_options(p.required_settings)
 
 
-def _get_user_settings(args):
+def _get_user_settings(args, provider=None):
     user_settings = UserOptions()
     if 'config' in vars(args):
-        user_settings.read_settings(filename=args.config)
+        user_settings.read_settings(filename=args.config, provider=provider)
     else:
-        user_settings.read_settings()
+        user_settings.read_settings(provider=provider)
     _merge_arguments(user_settings, vars(args))
     return user_settings
 

--- a/cloudomate/test/test_config.py
+++ b/cloudomate/test/test_config.py
@@ -40,6 +40,10 @@ class TestConfig(unittest.TestCase):
         self.config.put(key, value)
         self.assertEqual(self.config.get(key), value)
 
+    def test_custom_provider(self):
+        self.config = UserOptions()
+        self.config.read_settings("config_test.cfg", "testhoster")
+        self.assertEqual(self.config.get("email"), "test@test.net")
 
 if __name__ == '__main__':
     unittest.main()

--- a/cloudomate/util/config.py
+++ b/cloudomate/util/config.py
@@ -8,7 +8,7 @@ class UserOptions(object):
     def __init__(self):
         self.config = {}
 
-    def read_settings(self, filename=None):
+    def read_settings(self, filename=None, provider=None):
         cp = ConfigParser.ConfigParser()
         if not filename:
             config_dir = user_config_dir()
@@ -19,16 +19,20 @@ class UserOptions(object):
             return False
         cp.read(filename)
         try:
-            self._merge(cp.items("User"))
-            self._merge(cp.items("Address"))
-            self._merge(cp.items("Server"))
+            self._merge(cp, "User")
+            self._merge(cp, "Address")
+            self._merge(cp, "Server")
+            if provider:
+                self._merge(cp, provider)
         except NoSectionError, e:
             print(e.message)
             return False
         return True
 
-    def _merge(self, items):
-        for key, value in items:
+    def _merge(self, cp, section):
+        if section not in cp.sections():
+            return
+        for key, value in cp.items(section):
             self.config[key] = value
 
     def verify_options(self, options):

--- a/config_test.cfg
+++ b/config_test.cfg
@@ -17,3 +17,6 @@ zipcode = 123456
 ns1 = ns1
 ns2 = ns2
 hostname = hostname
+
+[testhoster]
+email = test@test.net


### PR DESCRIPTION
For example, an email address for rockhoster can be set by adding the
following to the configuration file:

[rockhoster]
email = rockhoster@cloudomate.test