### PR TITLE
Ssh

### DIFF
--- a/cloudomate/cmdline.py
+++ b/cloudomate/cmdline.py
@@ -1,7 +1,6 @@
+import subprocess
 import sys
 from argparse import ArgumentParser
-
-import subprocess
 
 from cloudomate.util.config import UserOptions
 from cloudomate.vps.blueangelhost import BlueAngelHost
@@ -97,6 +96,8 @@ def add_parser_ssh(subparsers):
     parser_ssh.add_argument("-n", "--number", help="The number of the service to SSH into")
     parser_ssh.add_argument("-e", "--email", help="The login email address")
     parser_ssh.add_argument("-pw", "--password", help="The login password")
+    parser_ssh.add_argument("-p", "--rootpw", help="The root password used to login")
+    parser_ssh.add_argument("-u", "--user", help="The user password used to login", default="root")
     parser_ssh.set_defaults(func=ssh)
 
 
@@ -257,8 +258,9 @@ def ssh(args):
     provider = _get_provider(args)
     user_settings = _get_user_settings(args, provider.name)
     ip = provider.get_ip(user_settings)
+    user = user_settings.get('user')
     try:
-        subprocess.call(['sshpass', '-p', user_settings.get('rootpw'), 'ssh', 'root@' + ip])
+        subprocess.call(['sshpass', '-p', user_settings.get('rootpw'), 'ssh', user + '@' + ip])
     except OSError, e:
         print(e)
         print('Install sshpass to use this command')

--- a/cloudomate/vps/blueangelhost.py
+++ b/cloudomate/vps/blueangelhost.py
@@ -138,4 +138,4 @@ class BlueAngelHost(Hoster):
 
     def get_ip(self, user_settings):
         clientarea = ClientArea(self.br, self.clientarea_url, user_settings)
-        print(clientarea.get_client_data_ip(self.client_data_url))
+        return clientarea.get_client_data_ip(self.client_data_url)

--- a/cloudomate/vps/crowncloud.py
+++ b/cloudomate/vps/crowncloud.py
@@ -175,4 +175,4 @@ class CrownCloud(Hoster):
         if not ip:
             print("No active IP found")
             sys.exit(2)
-        print(ip)
+        return ip

--- a/cloudomate/vps/linevast.py
+++ b/cloudomate/vps/linevast.py
@@ -218,4 +218,4 @@ class LineVast(Hoster):
 
     def get_ip(self, user_settings):
         clientarea = ClientArea(self.br, self.clientarea_url, user_settings)
-        print(clientarea.get_ip())
+        return clientarea.get_ip()

--- a/cloudomate/vps/pulseservers.py
+++ b/cloudomate/vps/pulseservers.py
@@ -185,4 +185,4 @@ class Pulseservers(Hoster):
 
     def get_ip(self, user_settings):
         clientarea = ClientArea(self.br, self.clientarea_url, user_settings)
-        print(clientarea.get_ip())
+        return clientarea.get_ip()

--- a/cloudomate/vps/rockhoster.py
+++ b/cloudomate/vps/rockhoster.py
@@ -169,4 +169,4 @@ class RockHoster(Hoster):
 
     def get_ip(self, user_settings):
         clientarea = ClientArea(self.br, self.clientarea_url, user_settings)
-        print(clientarea.get_client_data_ip(self.client_data_url))
+        return clientarea.get_client_data_ip(self.client_data_url)


### PR DESCRIPTION
Use 'cloudomate ssh <provider>' to create a remote shell to an active service. 
Cmdline refactored a bit.
The print of get_ip is moved from the hoster (which now returns instead of prints) to cmdline. This is useful for API usage of Cloudomate.